### PR TITLE
removed need for unsafe.Pointer

### DIFF
--- a/glu.go
+++ b/glu.go
@@ -44,12 +44,12 @@ func LookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ float64) 
 	)
 }
 
-func UnProject(winX, winY, winZ float64, model, proj, view unsafe.Pointer) (float64, float64, float64) {
+func UnProject(winX, winY, winZ float64, model, proj *[16]float64, view *[4]int32) (float64, float64, float64) {
 	var ox, oy, oz C.GLdouble
 
-	m := (*C.GLdouble)(model)
-	p := (*C.GLdouble)(proj)
-	v := (*C.GLint)(view)
+	m := (*C.GLdouble)(unsafe.Pointer(model))
+	p := (*C.GLdouble)(unsafe.Pointer(proj))
+	v := (*C.GLint)(unsafe.Pointer(view))
 
 	C.gluUnProject(
 		C.GLdouble(winX),


### PR DESCRIPTION
In my previous submission, to use glu.UnProject you needed to convert your [16]float64 and over values to an unsafe.Pointer before you passed in. With this commit, I've changed it so that you just pass the [16]float64 into the function and it takes care of getting the proper pointer.
