### PR TITLE
added _GLUfuncptr typedef to improve OSX compatibility

### DIFF
--- a/callback.h
+++ b/callback.h
@@ -7,6 +7,13 @@
 
 #include <GL/glu.h>
 
+//Apple's glu.h defines its function pointers a little differently, so this tries to fix things up:
+#ifdef __APPLE__
+#ifndef GLAPIENTRY
+typedef GLvoid (*_GLUfuncptr)(void);
+#endif
+#endif
+
 extern void goTessBeginData(GLenum type, void *polygon_data);
 extern void goTessVertexData(void *vertex_data, void *polygon_data);
 extern void goTessEndData(void *polygon_data);


### PR DESCRIPTION
This adds the _GLUfuncptr - missing from Apple's glu.h implementation - to callback.h so that callback.c compiles on OSX. The typedef will only be added if an OSX environment (**APPLE**) is detected _and_ GLAPIENTRY from the more widely used glu.h is _not_ defined, so it should work cross-platform. Disclaimer - I'm not really a C programmer.
