### PR TITLE
*_GLUfuncptr fix for MinGW32

### DIFF
--- a/callback.h
+++ b/callback.h
@@ -18,7 +18,7 @@ typedef GLvoid (*_GLUfuncptr)(void);
 #endif
 #endif
 #ifdef __MINGW32__
-typedef GLvoid (*_GLUfuncptr)(void);
+typedef void (APIENTRY *_GLUfuncptr)();
 #endif
 
 extern void goTessBeginData(GLenum type, void *polygon_data);


### PR DESCRIPTION
Fixes error "callback.h:21:18: error: conflicting types for '_GLUfuncptr'" for MinGW32
