### PR TITLE
Use go-gl-legacy/gl package.

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -6,7 +6,7 @@ package glu
 
 //#include "callback.h"
 import "C"
-import "github.com/go-gl/gl"
+import "github.com/go-gl-legacy/gl"
 import "unsafe"
 
 // ===========================================================================

--- a/constants.go
+++ b/constants.go
@@ -4,7 +4,7 @@
 
 package glu
 
-import "github.com/go-gl/gl"
+import "github.com/go-gl-legacy/gl"
 
 const (
 	// TessCallback

--- a/glu.go
+++ b/glu.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/go-gl/gl"
+	"github.com/go-gl-legacy/gl"
 )
 
 func ptr(v interface{}) unsafe.Pointer {

--- a/tesselator.go
+++ b/tesselator.go
@@ -10,7 +10,7 @@ package glu
 //   #include <GL/glu.h>
 // #endif
 import "C"
-import "github.com/go-gl/gl"
+import "github.com/go-gl-legacy/gl"
 import "unsafe"
 
 // Opaque object used for book keeping on the go side.

--- a/tesselator_test.go
+++ b/tesselator_test.go
@@ -5,7 +5,7 @@
 package glu
 
 import (
-	"github.com/go-gl/gl"
+	"github.com/go-gl-legacy/gl"
 	"testing"
 )
 


### PR DESCRIPTION
Per the go-gl: Massive Overhaul
https://docs.google.com/document/d/1zORKEEFPsJ5AujtPbtQYQquvAopuXb3whWud1sA7nAE/edit?usp=sharing
this has moved.

I was not able to run go get on a package that depended on this before
this change.